### PR TITLE
BUG: avoid sending HTTP GET requests with empty body

### DIFF
--- a/bluesky_queueserver_api/comm_threads.py
+++ b/bluesky_queueserver_api/comm_threads.py
@@ -86,7 +86,9 @@ class ReManagerComm_HTTP_Threads(ReManagerAPI_HTTP_Base):
             client_response = None
             request_method, endpoint, params = self._prepare_request(method=method, params=params)
             headers = headers or self._prepare_headers()
-            kwargs = {"json": params}
+            kwargs = {}
+            if request_method == "GET" and len(params) > 0:
+                kwargs.update({"json": params})
             if url_params:
                 kwargs.update({"params": url_params})
             if headers:


### PR DESCRIPTION
According to the HTTP specification [1], we should avoid sending a body when doing a GET request.

In normal scenarios, sending an empty body doesn't cause any problems, it simply gets ignored. However, some VPNs (like FortiNet) can be configured to block these requests, as per the SPEC:

"[...] and might lead some implementations to reject the request and close the connection because of its potential as a request smuggling attack"

By avoiding these scenarios, we ensure we are spec-complient, and no middleware software blocks the requests.

[1] - https://httpwg.org/specs/rfc9110.html#GET

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenace PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added

### Changed

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->
